### PR TITLE
Fix unused max radius for Burgernet alerts

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -148,7 +148,11 @@ class NLAlertBinarySensor(CoordinatorEntity, BinarySensorEntity):
             if circle:
                 centre_str, radius_str = circle.split()
                 clat, clon = [float(x) for x in centre_str.split(",")]
-                if haversine(lat, lon, clat, clon) <= float(radius_str):
+                distance = haversine(lat, lon, clat, clon)
+                if (
+                    distance <= float(radius_str)
+                    and distance <= self.max_radius_m
+                ):
                     return True
         return False
 

--- a/sensor.py
+++ b/sensor.py
@@ -198,7 +198,11 @@ class NLAlertSensor(CoordinatorEntity, SensorEntity):
             if circle:
                 centre_str, radius_str = circle.split()
                 clat, clon = [float(x) for x in centre_str.split(",")]
-                if haversine(lat, lon, clat, clon) <= float(radius_str):
+                distance = haversine(lat, lon, clat, clon)
+                if (
+                    distance <= float(radius_str)
+                    and distance <= self.max_radius_m
+                ):
                     return alert
 
         return None


### PR DESCRIPTION
## Summary
- respect `max_radius` for Burgernet alerts in sensor and binary_sensor

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684560681ef0832cbdddd005db84a5d9