### PR TITLE
Schedule NL Active Alert state updates on event loop

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -35,7 +35,7 @@ class NLActiveAlertBinarySensor(BinarySensorEntity):
 
     def _state_listener(self, event):
         """Trigger an update when any sensor changes."""
-        self.async_write_ha_state()
+        self.hass.loop.call_soon_threadsafe(self.async_write_ha_state)
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
### Motivation
- Fix a thread-safety warning caused by calling `async_write_ha_state` from a thread other than the event loop, which can lead to crashes or data corruption.
- Ensure the NL Active Alert binary sensor updates its state safely when any underlying sensor changes.
- Preserve the existing behavior of listening for state changes from the underlying sensors via `async_track_state_change_event`.

### Description
- Replace the direct call to `self.async_write_ha_state()` in `_state_listener` with `self.hass.loop.call_soon_threadsafe(self.async_write_ha_state)` to schedule the write on the event loop.
- The change is located in `binary_sensor.py` inside the `NLActiveAlertBinarySensor` class `_state_listener` method.
- The integration continues to monitor `sensor.amber_alert`, `sensor.burgernet_search`, and `sensor.nl_alert` and cleans up the listener on unload.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fda46a148832cb2e5805c7280e0c8)